### PR TITLE
low voltage alternating aux LED

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2021-03-25
+added BLF LT1 to `flash-light.sh` option.
+
 2021-03-15
 added MF01S to `flash-light.sh` option.
 

--- a/flashlight-firmware/anduril2/ToyKeeper/spaghetti-monster/anduril/aux-leds.c
+++ b/flashlight-firmware/anduril2/ToyKeeper/spaghetti-monster/anduril/aux-leds.c
@@ -26,11 +26,15 @@
 #if defined(USE_INDICATOR_LED) && defined(TICK_DURING_STANDBY)
 // beacon-like mode for the indicator LED
 void indicator_blink(uint8_t arg) {
-    
-
     #ifdef USE_VOLTAGE_LOW_BLINKING_INDICATOR
-    // slow blink aux LEDs when battery is empty
-    if (voltage < VOLTAGE_LOW) { indicator_led(arg & 1); return; }
+    // slow blink aux LEDs when battery is nearly empty
+    if (voltage < VOLTAGE_LOW) {
+        indicator_led(0);
+        return;
+    } else if (voltage < (uint8_t) (1.1*VOLTAGE_LOW)) {
+        indicator_led(! (arg & 3)); // 1/4th duty cycle
+        return;
+    }
     #else
     // turn off aux LEDs when battery is empty
     if (voltage < VOLTAGE_LOW) { indicator_led(0); return; }

--- a/flashlight-firmware/anduril2/ToyKeeper/spaghetti-monster/anduril/aux-leds.c
+++ b/flashlight-firmware/anduril2/ToyKeeper/spaghetti-monster/anduril/aux-leds.c
@@ -26,8 +26,15 @@
 #if defined(USE_INDICATOR_LED) && defined(TICK_DURING_STANDBY)
 // beacon-like mode for the indicator LED
 void indicator_blink(uint8_t arg) {
+    
+
+    #ifdef USE_VOLTAGE_LOW_BLINKING_INDICATOR
+    // slow blink aux LEDs when battery is empty
+    if (voltage < VOLTAGE_LOW) { indicator_led(arg & 1); return; }
+    #else
     // turn off aux LEDs when battery is empty
     if (voltage < VOLTAGE_LOW) { indicator_led(0); return; }
+    #endif
 
     #ifdef USE_FANCIER_BLINKING_INDICATOR
 

--- a/flashlight-firmware/anduril2/ToyKeeper/spaghetti-monster/anduril/aux-leds.c
+++ b/flashlight-firmware/anduril2/ToyKeeper/spaghetti-monster/anduril/aux-leds.c
@@ -201,10 +201,21 @@ void button_led_update(uint8_t mode, uint8_t arg) {
     // turn off aux LEDs when battery is empty
     // (but if voltage==0, that means we just booted and don't know yet)
     uint8_t volts = voltage;  // save a few bytes by caching volatile value
+    #ifdef USE_VOLTAGE_LOW_BLINKING_INDICATOR
+    // slow blink aux LEDs when battery is nearly empty
     if ((volts) && (volts < VOLTAGE_LOW)) {
         button_led_set(0);
         return;
+    } else if (volts < (uint8_t) (1.1*VOLTAGE_LOW)) {
+        button_led_set(! (arg & 3)); // 1/4th duty cycle
+        return;
     }
+    #else
+    if ((volts) && (volts < VOLTAGE_LOW)) {
+    button_led_set(0);
+    return;
+    }
+    #endif
 
     uint8_t pattern = (mode>>4);  // off, low, high, blinking, ... more?
 

--- a/flashlight-firmware/anduril2/ToyKeeper/spaghetti-monster/anduril/config-default.h
+++ b/flashlight-firmware/anduril2/ToyKeeper/spaghetti-monster/anduril/config-default.h
@@ -126,6 +126,10 @@
 // enable beacon mode
 #define USE_BEACON_MODE
 
+//enable/disable low voltage blinking for indicator and button lights
+//implementation in aux-leds.c
+//#define USE_VOLTAGE_LOW_BLINKING_INDICATOR
+
 // enable/disable various strobe modes
 //#define USE_BIKE_FLASHER_MODE
 //#define USE_PARTY_STROBE_MODE


### PR DESCRIPTION
added alternating aux LED pattern when voltage is low (turned on by defining USE_VOLTAGE_LOW_BLINKING_INDICATOR in specific flashlight's header)